### PR TITLE
Fixed minor issue and new style

### DIFF
--- a/devrant.black.theme.user.js
+++ b/devrant.black.theme.user.js
@@ -89,6 +89,7 @@
 
         .body-col2 .rantlist li .rantlist-vote-col.vote-state-unvoted .btn-vote-circle:hover,
         .body-col2 .rantlist-vote-col.vote-state-upvoted .plusone,
+        .body-col2 .rantlist-vote-col.vote-state-downvoted .minusone,
         .menu-notif.notif-badge,
         .menu-notif.notif-badge.notif-2digits,
         .vote-state-upvoted > .vote-scroll > .plusone.btn-vote-circle:nth-child(1),

--- a/devrant.black.theme.user.js
+++ b/devrant.black.theme.user.js
@@ -186,18 +186,17 @@
             /* Vote style */
             .body-col2 .rantlist-vote-col.vote-state-unvoted > .plusone,
             .body-col2 .rantlist-vote-col.vote-state-unvoted > .minusone,
-            .body-col2 .rantlist-vote-col.vote-state-upvoted > .plusone,
-            .body-col2 .rantlist-vote-col.vote-state-upvoted > .minusone {
+            .body-col2 .rantlist-vote-col.vote-state-upvoted > .minusone,
+            .body-col2 .rantlist-vote-col.vote-state-downvoted > .plusone {
                 color: #666666 !important;
                 background-color: transparent !important;
                 border: 2px solid #666666 !important;
                 transition: 0.2s ease-in-out;
             }
 
-
             .body-col2 .rantlist li .rantlist-vote-col.vote-state-unvoted .plusone.btn-vote-circle:hover,
-            .body-col2 .rantlist-vote-col.vote-state-unvoted > .plusone:hover,
-            .body-col2 .rantlist-vote-col.vote-state-upvoted > .plusone {
+            .body-col2 .rantlist-vote-col.vote-state-upvoted > .plusone,
+            .body-col2 .rantlist-vote-col.vote-state-downvoted > .plusone:hover {
                 background-color: transparent !important;
                 color: #007ACC !important;
                 border: 2px solid var(--colorSlim) !important;
@@ -205,7 +204,7 @@
 
             .body-col2 .rantlist li .rantlist-vote-col.vote-state-unvoted .minusone.btn-vote-circle:hover,
             .body-col2 .rantlist-vote-col.vote-state-upvoted > .minusone:hover,
-            .body-col2 .rantlist-vote-col.vote-state-unvoted > .minusone:hover {
+            .body-col2 .rantlist-vote-col.vote-state-downvoted > .minusone {
                 background-color: transparent !important;
                 color: #D55161 !important;
                 border: 2px solid #D55161 !important;

--- a/devrant.black.theme.user.js
+++ b/devrant.black.theme.user.js
@@ -15,6 +15,7 @@
 
     // start - settings
         var grayscale_images = false;
+        var slim_style = false;
     // end
 
     function getCookie(cname) {
@@ -55,6 +56,7 @@
             --colorMidBlue: gray !important;
             --colorNewsText: gray !important;
             --colorBg: black !important;
+            --colorSlim: #007ACC !important;
         }
 
         .rant-avatar-scroll {
@@ -164,7 +166,7 @@
             img, .notif-avatar {
                 -webkit-filter: grayscale(100%);
                 filter: grayscale(100%);
-            }
+	        }
 
             .notif-avatar,
             .notif-avatar-link > .icon-container {
@@ -178,6 +180,79 @@
                 filter: grayscale(100%) brightness(1);
             }
        `;
+    } else if (slim_style !== false) {
+        style = style + `
+
+            /* Vote style */
+            .body-col2 .rantlist-vote-col.vote-state-unvoted > .plusone,
+            .body-col2 .rantlist-vote-col.vote-state-unvoted > .minusone,
+            .body-col2 .rantlist-vote-col.vote-state-upvoted > .plusone,
+            .body-col2 .rantlist-vote-col.vote-state-upvoted > .minusone {
+                color: #666666 !important;
+                background-color: transparent !important;
+                border: 2px solid #666666 !important;
+                transition: 0.2s ease-in-out;
+            }
+
+
+            .body-col2 .rantlist li .rantlist-vote-col.vote-state-unvoted .plusone.btn-vote-circle:hover,
+            .body-col2 .rantlist-vote-col.vote-state-unvoted > .plusone:hover,
+            .body-col2 .rantlist-vote-col.vote-state-upvoted > .plusone {
+                background-color: transparent !important;
+                color: #007ACC !important;
+                border: 2px solid var(--colorSlim) !important;
+            }
+
+            .body-col2 .rantlist li .rantlist-vote-col.vote-state-unvoted .minusone.btn-vote-circle:hover,
+            .body-col2 .rantlist-vote-col.vote-state-upvoted > .minusone:hover,
+            .body-col2 .rantlist-vote-col.vote-state-unvoted > .minusone:hover {
+                background-color: transparent !important;
+                color: #D55161 !important;
+                border: 2px solid #D55161 !important;
+            }
+            /* Vote style */
+
+            /* Tag lists colour */
+            .rantlist-tags > a[href="/search?term=rant"] {
+                color: #D55161;
+                border: 1px solid #D55161 !important;
+            }
+
+            .rantlist-tags > a[href="/search?term=joke%2Fmeme"] {
+                color: #2A8B9D;
+                border: 1px solid #2A8B9D !important;
+            }
+
+            .rantlist-tags > a[href="/search?term=question"] {
+                color: #A973A2;
+                border: 1px solid #A973A2 !important;
+            }
+
+            .rantlist-tags > a[href="/search?term=devrant"] {
+                color: #F99A66;
+                border: 1px solid #F99A66 !important;
+            }
+
+            .rantlist-tags > a[href="/search?term=random"] {
+                color: #7BC8A4;
+                border: 1px solid #7BC8A4 !important;
+            }
+            /* Tag lists colour */
+
+            /* Notif style */
+            .notif-avatar,
+            .notif-avatar-link > .icon-container {
+                -webkit-filter: brightness(0.5);
+                filter: brightness(0.5);
+            }
+
+            .notif-new > .notif-avatar-link > .notif-avatar,
+            .notif-new > .notif-avatar-link > .icon-container {
+                -webkit-filter: brightness(1);
+                filter: brightness(1);
+            }
+            /* Notif style */
+        `;
     }
 
     GM_addStyle(style);

--- a/devrant.black.theme.user.js
+++ b/devrant.black.theme.user.js
@@ -166,13 +166,13 @@
                 filter: grayscale(100%);
             }
 
-            .notif-avatar > img,
+            .notif-avatar,
             .notif-avatar-link > .icon-container {
                 -webkit-filter: grayscale(100%) brightness(0.4);
                 filter: grayscale(100%) brightness(0.4);
             }
 
-            .notif-new > .notif-avatar-link > .notif-avatar > img,
+            .notif-new > .notif-avatar-link > .notif-avatar,
             .notif-new > .notif-avatar-link > .icon-container {
                 -webkit-filter: grayscale(100%) brightness(1);
                 filter: grayscale(100%) brightness(1);

--- a/devrant.black.theme.user.js
+++ b/devrant.black.theme.user.js
@@ -15,7 +15,7 @@
 
     // start - settings
         var grayscale_images = false;
-        var slim_style = true;
+        var slim_style = false;
     // end
 
     function getCookie(cname) {

--- a/devrant.black.theme.user.js
+++ b/devrant.black.theme.user.js
@@ -15,7 +15,7 @@
 
     // start - settings
         var grayscale_images = false;
-        var slim_style = false;
+        var slim_style = true;
     // end
 
     function getCookie(cname) {
@@ -188,6 +188,8 @@
             .body-col2 .rantlist-vote-col.vote-state-unvoted > .plusone,
             .body-col2 .rantlist-vote-col.vote-state-unvoted > .minusone,
             .body-col2 .rantlist-vote-col.vote-state-upvoted > .minusone,
+            .body-col2 .rantlist-vote-col.vote-state-novote > .plusone,
+            .body-col2 .rantlist-vote-col.vote-state-novote > .minusone,
             .body-col2 .rantlist-vote-col.vote-state-downvoted > .plusone {
                 color: #666666 !important;
                 background-color: transparent !important;


### PR DESCRIPTION
I found a bug with default theme when down voting a post not changing the style
![bug](https://user-images.githubusercontent.com/38621036/42744705-910f680e-88f8-11e8-813a-87bcc42de287.PNG)
I already fixed it with the last commit

Also a minor bug fix with grey scale old notif filter if the user doesn't have an avatar
![greyscalefix](https://user-images.githubusercontent.com/38621036/42744748-dae40c5a-88f8-11e8-86db-aff333344518.png)

I created a style for myself, fixed all the conflict with the default black one, and turning it on or off works like grayscale. Hope you don't mind merging it? (It's also okay if you didn't want to :smiley: )
![notif](https://user-images.githubusercontent.com/38621036/42744812-4de22606-88f9-11e8-88d0-f9ca15a56f0d.PNG)
![slimstyle](https://user-images.githubusercontent.com/38621036/42744816-51b779d4-88f9-11e8-80be-a2f8898d1f81.PNG)

